### PR TITLE
Fix layout on very big screens

### DIFF
--- a/frontend/src/assets/main.css
+++ b/frontend/src/assets/main.css
@@ -1,6 +1,14 @@
 @import 'base.css';
 
+html {
+    overflow: hidden;
+    background: var(--background-color);
+}
+
 body {
     background-color: var(--background-color);
     font-family: var(--question-font);
+    max-width: 1440px;
+    margin: 0 auto;
+    overflow: hidden;
 }

--- a/frontend/src/components/ListOfPlayers.vue
+++ b/frontend/src/components/ListOfPlayers.vue
@@ -20,7 +20,7 @@ onUnmounted(() => {
 <template>
   <div class="playerList">
     <ul>
-      <p> PLAYERS </p>
+      <li><p> PLAYERS </p></li>
       <li v-for="player in players" :key="player">{{ player }}</li>
     </ul>
   </div>
@@ -29,7 +29,7 @@ onUnmounted(() => {
 <style scoped>
 
 .playerList {
-  font-size: 1.5em;
+  font-size: 1.45em;
   max-width: 318px;
   max-height: 500px;
   font-family: var(--question-font);


### PR DESCRIPTION
The content of every page is now limited to a max-width of 1440px and is always centered on larger screens.

I had to slightly adjust the font-size of the .playerList to prevent it from overflowing and get cut off. 

I also put the p tag "heading" of the players list in an `<li>` element to get rid of some warnings. This is a lazy fix, and this should probably be fixed later by putting the heading outside of the surrounding `<ul>` element and apply appropriate CSS for positioning.